### PR TITLE
Add pod for set_emit_newlines()

### DIFF
--- a/Strip.pm
+++ b/Strip.pm
@@ -227,6 +227,11 @@ set of strip tags.
 Takes a boolean value.  If set to false, HTML::Strip will not attempt
 any conversion of tags into spaces.  Set to true by default.
 
+=item set_emit_newlines()
+
+Takes a boolean value.  If set to true, HTML::Strip will output newlines
+after C<E<lt>brE<gt>> and C<E<lt>pE<gt>> tags.  Set to false by default.
+
 =item set_decode_entities()
 
 Takes a boolean value.  If set to false, HTML::Strip will not decode HTML


### PR DESCRIPTION
HTML::Strip was missing documentation for a new sub added in v2.11, `set_emit_newlines()`.  This prevented the module from installing on machines with Test::Pod::Coverage because *t/420_pod_coverage.t* fails.

The documentation may _actually_ be correct, too!  It looks correct from my reading of Strip.xs and it allows the pod coverage test to pass.